### PR TITLE
Remove unexpected require

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -2,8 +2,6 @@
 
 namespace RecastAI;
 
-require 'vendor/autoload.php';
-
 /**
  * Class Client
  * @package RecastAI

--- a/src/apis/Connect/Connect.php
+++ b/src/apis/Connect/Connect.php
@@ -2,8 +2,6 @@
 
 namespace RecastAI\apis\Connect;
 
-require 'vendor/autoload.php';
-
 /**
 * Class Connect
 * @package RecastAI

--- a/src/apis/Request/Request.php
+++ b/src/apis/Request/Request.php
@@ -2,8 +2,6 @@
 
 namespace RecastAI\apis\Request;
 
-require 'vendor/autoload.php';
-
 /**
 * Class Request
 * @package RecastAI


### PR DESCRIPTION
There is no need to require the autoload in the package's class, moreover the path is wrong when using composer, it should be something like  `../../vendor/autoload.php`.